### PR TITLE
Index the title in a separated database prefix.

### DIFF
--- a/xapianIndexer.cpp
+++ b/xapianIndexer.cpp
@@ -72,6 +72,7 @@ void XapianIndexer::indexingPrelude(const string indexPath_)
   this->writableDatabase.set_metadata("valuesmap", "title:0;wordcount:1");
   this->writableDatabase.set_metadata("language", language);
   this->writableDatabase.set_metadata("stopwords", stopwords);
+  this->writableDatabase.set_metadata("prefixes", "S");
   this->writableDatabase.begin_transaction(true);
 }
 
@@ -94,6 +95,7 @@ void XapianIndexer::index(const string& url,
   if (!unaccentedTitle.empty()) {
     this->indexer.index_text_without_positions(
         unaccentedTitle, this->getTitleBoostFactor(content.size()));
+    this->indexer.index_text(unaccentedTitle, 1, "S");
   }
 
   /* Index the keywords */


### PR DESCRIPTION
By default text is indexed without prefix.
But xapian allow indexing in specific prefix when indexing specific thing.

We use the "S" prefix (common prefix for "Subject" or "Title") to index
the title.

This will allow search on the title only.


From my test, the zim file is 1,5% bigger. (nopic, only articles starting by "a")