### PR TITLE
Revert "Add leading `/` at to indexing token url."

### DIFF
--- a/xapianIndexer.cpp
+++ b/xapianIndexer.cpp
@@ -139,7 +139,7 @@ void XapianIndexer::handleArticle(Article* article)
     return;
 
   token.title = article->getTitle();
-  token.url = "/" + std::string(1, article->getNamespace()) + '/' + article->getUrl();
+  token.url = std::string(1, article->getNamespace()) + '/' + article->getUrl();
   zim::Blob article_content = article->getData();
   token.content = std::string(article_content.data(), article_content.size());
 


### PR DESCRIPTION
This reverts commit 12b8b4e1c70409854471fb7b323fc7578212775a.

Fix #37