### PR TITLE
Store the xapian database using the right url.

### DIFF
--- a/xapianIndexer.h
+++ b/xapianIndexer.h
@@ -41,8 +41,8 @@ class XapianMetaArticle : public Article
  public:
   XapianMetaArticle(XapianIndexer* indexer) : indexer(indexer)
   {
-    ns = 'Z';
-    aid = url = "/fulltextIndex/xapian";
+    ns = 'X';
+    aid = url = "fulltext/xapian";
     title = "Xapian Fulltext Index";
     mimeType = "application/octet-stream+xapian";
   };


### PR DESCRIPTION
!!! WARNING

This have to be merged later.
This PR change where the xapian database is stored in a zim file.
New version of libzim will search in both location (old `Z//fulltextIndex/xapian` and new `X/fulltext/xapian`)
but older libzim only search in the old location.

Once we assume that new version of libzim has been spread out enough, we should be able to merge this. Not before.

Fix #35 