### PR TITLE
Never detect an empty mimetype.

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -506,9 +506,11 @@ std::string getMimeTypeForFile(const std::string& filename)
       mimeType = mimeType.substr(0, mimeType.find(";"));
     }
     fileMimeTypes[filename] = mimeType;
+  } catch (...) { }
+  if (mimeType.empty()) {
+    return "application/octet-stream";
+  } else {
     return mimeType;
-  } catch (...) {
-    return "";
   }
 }
 

--- a/travis/install_deps.sh
+++ b/travis/install_deps.sh
@@ -13,6 +13,8 @@ then
   brew upgrade python3
   pip3 install meson==0.43.0
 
+  brew install libmagic
+
   wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip
   unzip ninja-mac.zip ninja
 else


### PR DESCRIPTION
mimetype should not be empty. If something goes wrong while detecting
the mimetype, return "application/octet-stream".

See #48