### PR TITLE
Fix issue #28

### DIFF
--- a/src/article.h
+++ b/src/article.h
@@ -149,18 +149,16 @@ class FileArticle : public Article
 class RedirectArticle : public Article
 {
  public:
-  RedirectArticle(const std::string& line)
+  explicit RedirectArticle(char ns,
+                           const std::string& url,
+                           const std::string& title,
+                           const std::string& redirectAid)
   {
-    size_t start;
-    size_t end;
-    ns = line[0];
-    end = line.find_first_of("\t", 2);
-    url = line.substr(2, end - 2);
-    start = end + 1;
-    end = line.find_first_of("\t", start);
-    title = line.substr(start, end - start);
-    redirectAid = line.substr(end + 1);
-    aid = "/" + line.substr(0, 1) + "/" + url;
+    this->ns = ns;
+    this->url = url;
+    this->title = title;
+    this->redirectAid = redirectAid;
+    aid = std::string("/") + ns + "/" + url;
     mimeType = "text/plain";
   }
   virtual zim::Blob getData() const { return zim::Blob(); }

--- a/src/zimcreatorfs.cpp
+++ b/src/zimcreatorfs.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <regex>
 
 bool isVerbose();
 
@@ -39,8 +40,23 @@ void ZimCreatorFS::add_redirectArticles_from_file(const std::string& path)
   std::string line;
 
   in_stream.open(path.c_str());
+  int line_number = 1;
   while (std::getline(in_stream, line)) {
-    addArticle(RedirectArticle(line));
+    std::regex line_regex("(.)\\t(.+)\\t(.+)\\t(.+)");
+    std::smatch matches;
+    if (!std::regex_search(line, matches, line_regex) || matches.size() != 5) {
+      std::cerr << "zimwriterfs: line #" << line_number
+                << " has invalid format in redirect file " << path << ": '"
+                << line << "'" << std::endl;
+      in_stream.close();
+      exit(1);
+    }
+
+    addArticle(RedirectArticle(matches[1].str()[0],
+                               matches[2].str(),
+                               matches[3].str(),
+                               matches[4].str()));
+    ++line_number;
   }
   in_stream.close();
 }


### PR DESCRIPTION
Tested with the following test cases:

```
$ ./zimwriterfs --welcome=index.html --favicon=Test.png --language=fra --title=foobar --description=mydescription --creator=Wikipedia --publisher=Kiwix -r correct.tsv ./html my_project.zim
A:17; CA:15; UA:2; FA:1; IA:1; C:0; CC:0; UC:0
sort 17 directory entries (aid)
remove invalid redirects from 17 directory entries
0/17 directory entries checked for invalid redirects
remove invalid redirection Como.html redirecting to (missing) Como.html
remove invalid redirection LANZHOU.html redirecting to (missing) LANZHOU.html
remove invalid redirection Nord-ouest_argentin.html redirecting to (missing) Nord-ouest_argentin.html
remove invalid redirection Nürnberg.html redirecting to (missing) Nürnberg.html
remove invalid redirection Yeu.html redirecting to (missing) Yeu.html
sort 12 directory entries (url)
set index
translate redirect aid to index
create title index
12 title index created
2 clusters created
fill header
write zimfile
ready
```

```
$ ./zimwriterfs --welcome=index.html --favicon=Test.png --language=fra --title=foobar --description=mydescription --creator=Wikipedia --publisher=Kiwix -r incorrect.tsv ./html my_project.zim
zimwriterfs: line #1 has invalid format in redirect file incorrect.tsv: '              A '
```