### PR TITLE
Fix #59 : use option --default-library=static for static build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ add_global_arguments('-DVERSION=@0@'.format(meson.project_version()), language :
 compiler = meson.get_compiler('cpp')
 find_library_in_compiler = meson.version().version_compare('>=0.31.0')
 
-static_linkage = get_option('static-linkage')
+static_linkage = (get_option('default_library')=='static'))
 if static_linkage
   add_global_link_arguments('-static-libstdc++', '--static', language:'cpp')
 endif

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ add_global_arguments('-DVERSION=@0@'.format(meson.project_version()), language :
 compiler = meson.get_compiler('cpp')
 find_library_in_compiler = meson.version().version_compare('>=0.31.0')
 
-static_linkage = (get_option('default_library')=='static'))
+static_linkage = (get_option('default_library')=='static')
 if static_linkage
   add_global_link_arguments('-static-libstdc++', '--static', language:'cpp')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,2 @@
-option('static-linkage', type : 'boolean', value : false,
-  description : 'Create statically linked binaries.')
 option('magic-install-prefix', type : 'string', value : '',
   description : 'Prefix where libmagic has been installed')

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -8,10 +8,10 @@ INSTALL_DIR=${BUILD_DIR}/INSTALL
 
 case ${PLATFORM} in
   "native_static")
-    MESON_OPTION="-Dstatic-linkage=true"
+    MESON_OPTION="--default-library=static"
     ;;
   "native_dyn")
-    MESON_OPTION=""
+    MESON_OPTION="--default-library=shared"
     ;;
 esac
 


### PR DESCRIPTION
According README we should use  `--default-library=static` for static build, but it's was not the case in the meson configuration (before : `-Dstatic-linkage=true`). Since libzim also use `--default-library=static`, we update zimwriterfs to use the same option for static build.