### PR TITLE
Fix #59 : Update README with good information about static building

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ ninja -C build
 By default, it will compile dynamic linked libraries. All binary files
 will be created in the "build" directory created automatically by
 Meson. If you want statically linked libraries, you can add
-`--default-library=static` option to the Meson command.
+`-Dstatic-linkage=true` option to the Meson command.
 
 Depending of you system, `ninja` may be called `ninja-build`.
 


### PR DESCRIPTION
Fix readme information about static building : `-Dstatic-linkage=true` should be used (see https://github.com/openzim/zimwriterfs/issues/59#issuecomment-426940657)