### PR TITLE
Remove reference to xapian.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ need to be available:
 * gumbo (https://github.com/google/gumbo-parser), a pure-C DOM parser
 * libicu (http://site.icu-project.org/), for unicode string
   manipulation. It'always packaged
-* libxapian (https://xapian.org), which provide fulltext search
-  indexing features.
 
 On (recent) Debian/Ubuntu, you can ensure these are installed with:
 

--- a/meson.build
+++ b/meson.build
@@ -13,8 +13,6 @@ if static_linkage
   add_global_link_arguments('-static-libstdc++', '--static', language:'cpp')
 endif
 
-conf = configuration_data()
-
 thread_dep = dependency('threads')
 libzim_dep = dependency('libzim', version : '>=4.0.0', static:static_linkage)
 zlib_dep = dependency('zlib', static:static_linkage)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,2 +1,0 @@
-
-#mesondefine HAVE_XAPIAN

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,3 @@
-configure_file(output : 'config.h',
-               configuration : conf,
-               input : 'config.h.in')
-
 sources = [
   'zimwriterfs.cpp',
   'tools.cpp',

--- a/src/zimwriterfs.cpp
+++ b/src/zimwriterfs.cpp
@@ -34,7 +34,6 @@
 #include "mimetypecounter.h"
 #include "queue.h"
 #include "tools.h"
-#include "config.h"
 
 /* Check for version number */
 #ifndef VERSION


### PR DESCRIPTION
Xapian has been moved to libzim. It is not in zimwriterfs.
Remove the reference to it in the README.

The `config.h` was only use to set the HAVE_XAPIAN define. So we can
remove it.

Fix #99