### PR TITLE
Correctly set the main page.

### DIFF
--- a/src/zimcreatorfs.cpp
+++ b/src/zimcreatorfs.cpp
@@ -29,9 +29,9 @@
 
 bool isVerbose();
 
-std::string ZimCreatorFS::getMainPage()
+zim::writer::Url ZimCreatorFS::getMainUrl()
 {
-  return mainPage;
+  return zim::writer::Url('A', mainPage);
 }
 
 void ZimCreatorFS::add_redirectArticles_from_file(const std::string& path)

--- a/src/zimcreatorfs.h
+++ b/src/zimcreatorfs.h
@@ -42,7 +42,7 @@ class ZimCreatorFS : public zim::writer::Creator
     : zim::writer::Creator(verbose),
       mainPage(mainPage) {}
   virtual ~ZimCreatorFS() = default;
-  virtual std::string getMainPage();
+  virtual zim::writer::Url getMainUrl();
    virtual void add_customHandler(IHandler* handler);
    virtual void add_redirectArticles_from_file(const std::string& path);
    virtual void visitDirectory(const std::string& path);


### PR DESCRIPTION
The name of the method has changed in libzim.
We must also change it in our creator, else `getMainPage` is just a
unused method and zim's creator use the default implementation for
`getMainUrl` (ie, no main page).