### PR TITLE
Fix url() issue in CSS files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+zimwriterfs 1.3.5
+=================
+
+ * Fix resources URL rewriting in CSS files
+
 zimwriterfs 1.3.4
 =================
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,11 +3,11 @@ FROM ubuntu:latest
 # Update system
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update -y
-RUN apt-get install -y apt-utils
+RUN apt-get install -y --no-install-recommends apt-utils
 RUN apt-get dist-upgrade -y
 
 # Configure locales
-RUN apt-get install locales
+RUN apt-get install -y --no-install-recommends locales
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('zimwriterfs', ['c', 'cpp'],
-  version : '1.3.4',
+  version : '1.3.5',
   license : 'GPL-3.0-or-later',
   default_options : ['c_std=c11', 'cpp_std=c++11', 'werror=true'])
 

--- a/src/article.cpp
+++ b/src/article.cpp
@@ -180,6 +180,7 @@ void FileArticle::parseAndAdaptHtml(bool detectRedirects)
   std::map<std::string, bool> links;
   getLinks(root, links);
   std::string longUrl = std::string("/") + ns + "/" + url;
+
   /* If a link appearch to be duplicated in the HTML, it will
      occurs only one time in the links variable */
   for (auto& linkPair: links) {
@@ -203,6 +204,7 @@ void FileArticle::adaptCss() {
 
   while ((startPos = data.find("url(", endPos))
          && startPos != std::string::npos) {
+
     /* URL delimiters */
     endPos = data.find(")", startPos);
     startPos = startPos + (data[startPos + 4] == '\''
@@ -218,6 +220,7 @@ void FileArticle::adaptCss() {
     std::string endDelimiter = data.substr(endPos, 1);
 
     if (url.substr(0, 5) != "data:") {
+
       /* Deal with URL with arguments (using '? ') */
       std::string path = url;
       size_t markPos = url.find("?");

--- a/src/article.cpp
+++ b/src/article.cpp
@@ -236,7 +236,7 @@ void FileArticle::adaptCss() {
           || mimeType == "application/vnd.ms-fontobject") {
         try {
           std::string fontContent = getFileContent(
-              directoryPath + "/" + computeAbsolutePath(url, path));
+              directoryPath + "/" + computeAbsolutePath(this->url, path));
           replaceStringInPlaceOnce(
               data,
               startDelimiter + url + endDelimiter,
@@ -256,7 +256,7 @@ void FileArticle::adaptCss() {
         replaceStringInPlaceOnce(
             data,
             startDelimiter + url + endDelimiter,
-            startDelimiter + computeNewUrl(url, longUrl, path) + endDelimiter);
+            startDelimiter + computeNewUrl(this->url, longUrl, path) + endDelimiter);
       }
     }
   }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -135,7 +135,6 @@ inline std::string inflateString(const std::string& str)
     if (outstring.size() < zs.total_out) {
       outstring.append(outbuffer, zs.total_out - outstring.size());
     }
-
   } while (ret == Z_OK);
 
   inflateEnd(&zs);

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -332,7 +332,7 @@ std::vector<std::string> split(const std::string& lhs, const char* rhs)
 std::string computeAbsolutePath(const std::string& path,
                                 const std::string& relativePath)
 {
-  /* Add a trailing / to the path if necessary */
+  /* Remove leaf part of the path if not already a directory */
   std::string absolutePath = path[path.length() - 1] == '/'
                                  ? path
                                  : removeLastPathElement(path, false, false);

--- a/src/zimwriterfs.cpp
+++ b/src/zimwriterfs.cpp
@@ -77,7 +77,6 @@ void version()
   std::cout << "Version:  " << "v" << VERSION << std::endl;
   std::cout << "\tSee -h or --help argument flags for further argument options" << std::endl;
   std::cout << "\tCopyright 2013-2016 Emmanuel Engelhart <kelson@kiwix.org>" << std::endl;
-
 }
 
 /* Print correct console usage options */
@@ -293,13 +292,10 @@ int main(int argc, char** argv)
     exit(1);
   }
 
-
-
   /* System tags */
   if (withFullTextIndex) {
     tags += tags.empty() ? "" : ";";
     tags += "_ftindex";
-
   }
 
   setenv("ZIM_LZMA_LEVEL", "9e", 1);


### PR DESCRIPTION
zimwriterfs parses CSS files to find `url()` instructions and replace its content with an updated in-ZIM URL.
Goal is to replace `url(../img/bg.png)` inside `styles/css/style.css` with `url(../../I/styles/img/bg.png)`.

This happens in `computeNewUrl(string& aid, string& baseUrl, string& targetUrl)` and `computeAbsolutePath(string& path,
string& relativePath)` calls (the first calling the latter).

The problem is that we are calling `computeNewUrl(url, longUrl, path);` where `url` is a local variable containing the image target URL and not the CSS *parent* file URL. Without this information, `computeAbsolutePath(url, path)` is unable to guess where the relative `url()` info starts from.

I am confident **this is a typo** as it is used properly in `parseAndAdaptHtml()` using `url` but there, `url` is not defined locally and this is brought from `this->url`.