### PR TITLE
Update Brew before using it

### DIFF
--- a/travis/install_deps.sh
+++ b/travis/install_deps.sh
@@ -10,6 +10,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]
 then
   pip3 install meson
 
+  brew update
   brew install libmagic
 
   wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip


### PR DESCRIPTION
To avoid error:
```
/usr/local/Homebrew/Library/Homebrew/brew.rb:10:in `<main>': Homebrew must be run under Ruby 2.6! You're running 2.3.3. (RuntimeError)

The command "travis/install_deps.sh" failed and exited with 1 during .
```

https://travis-ci.org/openzim/zimwriterfs/jobs/609589456