### PR TITLE
set proper MIME type for wasm files

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -110,6 +110,8 @@ static std::map<std::string, std::string> _create_extMimeTypes()
   extMimeTypes["ODP"] = "application/vnd.oasis.opendocument.text";
   extMimeTypes["zip"] = "application/zip";
   extMimeTypes["ZIP"] = "application/zip";
+  extMimeTypes["wasm"] = "application/wasm";
+  extMimeTypes["WASM"] = "application/wasm";
 
   return extMimeTypes;
 }


### PR DESCRIPTION
While not mandatory, serving WebAssembly files with the proper MIME type is the recommended way of using it as it has better performances and ensures its content (the wasm file) can be streamed.

See [the spec](https://webassembly.org/docs/web/) for details, especially the *Process a potential WebAssembly response* part.